### PR TITLE
Added manual warning to user in pySME setting, general commentary, and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Planet = StarRotator(586.0,592.0,200.0,input=input_dict)
 
 ### A typical use case: running StarRotator with pySME as a forward model.
 
-[PySME](https://github.com/AWehrhahn/SME) is used in StarRotator to allow a user to generate more precise forward-models of the Doppler-Shadow residuals for real exoplanet systems. Using known stellar parameters (T, log(g), Z, vsin i) and individual elemental abundances, in theory it should be possible to precisely forward model the residual and recalibrate observed spectra. To the broadened spectrum in the Na lines in a sodium-rich variation on the KELT-9 system with pySME, you can use the following example.
+[PySME](https://github.com/AWehrhahn/SME) is used in StarRotator to allow a user to generate more precise forward-models of the Doppler-Shadow residuals for real exoplanet systems. Using known stellar parameters (T, log(g), Z, vsin i) and individual elemental abundances, in theory it should be possible to precisely forward model the residual and recalibrate observed spectra. To the broadened spectrum in the Na lines in a sodium-rich variation on the KELT-9 system with pySME, you can use the following example. Please be reminded that the provided demo line list `input\demo_linelist.dat` contains ONLY stellar lines for Na in the wavelength range of the Fraunhofer D lines. For any other wavelength range and element, see section below on VALD line lists.
 
 
 ```python

--- a/lib/integrate.py
+++ b/lib/integrate.py
@@ -1,5 +1,5 @@
 def statusbar(i,x):
-    """A beautiful percentage indicator for for-loops.
+    """A percentage indicator for for-loops.
         Parameters
         ----------
         i : float
@@ -61,11 +61,9 @@ def input_tests_global(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid,fname=''):
         raise Exception("Value error in "+fname+": wlmin (%s) is smaller than min(wl) (%s) after accounting for the maximum velocity shift (%s)" % (wlmin/ops.doppler(dvm),min(wl),dvm))
     if wlmax*ops.doppler(dvm) >= np.nanmax(wl):
         raise Exception("Value error in "+fname+": wlmax (%s) is greater than max(wl) (%s) after accounting for the maximum velocity shift (%s)" % (wlmax*ops.doppler(dvm),max(wl),dvm))
-
-
-
     #fname should be a string.
     test.typetest(fname,str,varname='fname in input_tests_global')
+
 
 def build_local_spectrum_fast(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
     """This is the fast and easy way of building the missing local spectrum that
@@ -126,8 +124,8 @@ def build_local_spectrum_fast(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
     input_tests_local(xp,yp,RpRs)
     input_tests_global(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid,fname='build_local_spectrum_fast')
 
-    #We start by creating a mask that selects just the area of the star that is
-    #covered by the planet, as well as its inverse which we like to return for
+    #Creates a mask that selects just the area of the star that is
+    #covered by the planet, as well as its inverse for
     #plotting purposes.
     x_full = np.tile(x,(len(y),1))-xp
     y_full = np.tile(y,(len(x),1)).T-yp
@@ -152,7 +150,7 @@ def build_local_spectrum_fast(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
         v=np.nanmedian(vel_grid,axis = 0)
-    #Here we only loop over columns. The summation in the vertical direction is contained
+    #loop over columns. The summation in the vertical direction is contained
     #in the flux variable.
     for i in range(len(x)):
         if np.isnan(v[i]) == False:
@@ -164,7 +162,7 @@ def build_local_spectrum_fast(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
 def build_local_spectrum_slow(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
     """This is the brute-force (slow) way of building the missing local spectrum that
     is blocked by the planet, applicable to any velocity/flux grid. This is used when differential
-    rotation is a thing.
+    rotation is desired.
 
         Parameters
         ----------
@@ -219,8 +217,8 @@ def build_local_spectrum_slow(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
     input_tests_global(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid,fname='build_local_spectrum_slow')
 
 
-    #We start by creating a mask that selects just the area of the star that is
-    #covered by the planet, as well as its inverse which we like to return for
+    #Creates a mask that selects just the area of the star that is
+    #covered by the planet, as well as its inverse for
     #plotting purposes.
     x_full = np.tile(x,(len(y),1))-xp
     y_full = np.tile(y,(len(x),1)).T-yp
@@ -235,7 +233,7 @@ def build_local_spectrum_slow(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
     if zp < 0.0:
         d*=np.nan#Force the planet to not be in front of the disk if the z-coordinate is such that it is behind the star.
         di[np.isnan(di)]=1.0#started as 1.0, set back to 1.0
-    mask = flux_grid*(d*0.0+1.0)#Set that to 1.0 and multiply with flux grid. Nansum coming!
+    mask = flux_grid*(d*0.0+1.0)#Set to 1.0 and multiply with flux grid. Nansum coming!
     mask_i = flux_grid*(di*0.0+1.0)#Inverse of mask.
 
     wlc,fxc,wlc_wide,fxc_wide = ops.clip_spectrum(wl,fx,wlmin,wlmax,pad=2.0*np.nanmax(np.abs(vel_grid)))
@@ -247,12 +245,8 @@ def build_local_spectrum_slow(xp,yp,zp,RpRs,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_
         for j in range(len(y)):
             if np.isnan(mask[j,i]) == False:
                 F+=ops.shift(wlc,wlc_wide,fxc_wide,vel_grid[j,i])*flux_grid[j,i]
-        # statusbar(i,len(x))
+
     return(wlc,F,np.nansum(mask_i),(di*0.0)+1.0)
-
-
-
-
 
 
 def build_spectrum_fast(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
@@ -312,9 +306,6 @@ def build_spectrum_fast(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
 
 
 
-
-
-
 def build_spectrum_slow(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
     """This is the default, brute-force way of integrating the spectrum.
         Parameters
@@ -351,27 +342,48 @@ def build_spectrum_slow(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid):
     wlc,fxc,wlc_wide,fxc_wide = ops.clip_spectrum(wl,fx,wlmin,wlmax,pad=2.0*np.nanmax(np.abs(vel_grid)))
 
     F = 0#output
-    # start = time.time()
     for i in range(len(x)):
         for j in range(len(y)):
             if np.isnan(vel_grid[j,i]) == False:
                 F+=ops.shift(wlc,wlc_wide,fxc_wide,vel_grid[j,i])*flux_grid[j,i]
         statusbar(i,len(x))
-    # print(time.time()-start)
     return(wlc,F)
 
 
 
 def build_spectrum_limb_resolved(wl,fx_list,mu_list,wlmin,wlmax,x,y,vel_grid,flux_grid):
-    """WRITE THIS.
+    """Integrates the spectrum with resolved limbs. As a consequence wl and fx are narrow by construction
+    and the standard clipping had to be adapted. 
         Parameters
         ----------
+        wl : np.array()
+            The stellar model wavelength(s) in nm.
 
+        fx_list : np.array()
+            The stellar model flux.
+
+        mu_list: np.array()
+            List of mu arrays to be considered.
+
+        wlmin: float
+            The minimum wavelength to be considered, in units of wl.
+
+        wlmax: float
+            The maximum wavelength to be considered, in units of wl.
+
+        x,y:
+            The x and y axis of the velocity grid, typically in units of stellar
+            radius.
+
+        vel_grid: 2D np.array()
+            The velocity grid of the stellar disk. Values outside of the disk are
+            to be set to NaN.
+
+        flux_grid: 2D np.array()
+            The broad-band flux map of the stellar disk. Should have the same
+            dimensions and axes as vel_grid.
     """
-    #I copy paste as much as possible from above. The roles of wlc and wlc_wide have
-    #changed because wl,fx is already narrow by construction. Therefore in order to
-    #crop the spectrum with margin, I actually need to crop the wl axis inwards.
-    #To do this, I needed to convert clip_spectrum to crop_spectrum.
+
     import numpy as np
     import lib.operations as ops
     import lib.stellar_spectrum as spectrum
@@ -385,7 +397,6 @@ def build_spectrum_limb_resolved(wl,fx_list,mu_list,wlmin,wlmax,x,y,vel_grid,flu
     input_tests_global(wlc_wide,fx_list[0],wlmin,wlmax,x,y,vel_grid,vel_grid,fname='build_spectrum_limb_resolved')
     wlc,fxc = ops.crop_spectrum(wl,fx_list[0],1.0*np.nanmax(np.abs(vel_grid)))#I do this for only one spectrum because I only care about wlc
     F = 0#output
-    # start = time.time()
     
     # Calculate radii at the edge of the annuli
     rmu = np.sqrt(1 - mu_list**2)
@@ -403,10 +414,8 @@ def build_spectrum_limb_resolved(wl,fx_list,mu_list,wlmin,wlmax,x,y,vel_grid,flu
                 index = np.where(r < rlist)[-1][-1]
                 if mu_list[index] > 0:
                     fxc_wide = fx_list[index]
-                    # print(i,j,x[i],y[j],mu,mu_list[index])
                     F+=ops.shift(wlc,wlc_wide,fxc_wide,vel_grid[j,i])*flux_grid[j,i]
         statusbar(i,len(x))
-    # print(time.time()-start)
     return(wlc,F)
 
 
@@ -472,8 +481,8 @@ def build_local_spectrum_limb_resolved(xp,yp,zp,RpRs,wl,fx_list,mu_list,wlmin,wl
     test.typetest(mu_list,np.ndarray,varname='mu_list in build_local_spectrum_limb_resolved')
     test.dimtest(mu_list,[len(fx_list)],varname='mu_list in build_local_spectrum_limb_resolved')
 
-    #We start by creating a mask that selects just the area of the star that is
-    #covered by the planet, as well as its inverse which we like to return for
+    #Create a mask that selects just the area of the star that is
+    #covered by the planet, as well as its inverse for
     #plotting purposes.
     x_full = np.tile(x,(len(y),1))-xp
     y_full = np.tile(y,(len(x),1)).T-yp
@@ -490,21 +499,14 @@ def build_local_spectrum_limb_resolved(xp,yp,zp,RpRs,wl,fx_list,mu_list,wlmin,wl
         di[np.isnan(di)]=1.0#started as 1.0, set back to 1.0
     mask = flux_grid*(0.0*vel_grid+1.0)*(d*0.0+1.0)#Set that to 1.0 and multiply with flux grid. Nansum coming!
     mask_i = flux_grid*(0.0*vel_grid+1.0)*(di*0.0+1.0)#Inverse of mask.
-#MOVE ALL OF THIS INTO A WRAPPER? I THINK THIS IS NOW COPYPASTED 3 TIMES?
-#ACTUALLY, NOW I AM USING VEL GRID INS TEAD OF FLUX GRID. THAT MEANS THAT THE
-#FLUX IS NO LONGER CALCULATED PROPERLY. NO LIGHTCURVE!
-    # wlc,fxc,wlc_wide,fxc_wide = ops.clip_spectrum(wl,fx,wlmin,wlmax,pad=2.0*np.nanmax(np.abs(vel_grid)))
-    wlc,fxc = ops.crop_spectrum(wl,fx_list[0],1.0*np.nanmax(np.abs(vel_grid)))#I do this for only one spectrum because I only care about wlc
-
+    wlc,fxc = ops.crop_spectrum(wl,fx_list[0],1.0*np.nanmax(np.abs(vel_grid)))# only one spectrum because we only care about wlc
 
     F = 0#output
-    # start = time.time()
     
     # Calculate radii at the edge of the annuli
     rmu = np.sqrt(1 - mu_list**2)
     rlist = np.sqrt(0.5 * (rmu[:-1] ** 2 + rmu[1:] ** 2))  # area midpoints between rmu
     rlist = np.concatenate(([1], rlist))
-    # pdb.set_trace()
     for i in range(len(x)):
         for j in range(len(y)):
             if np.isnan(mask[j,i]) == False:
@@ -513,18 +515,6 @@ def build_local_spectrum_limb_resolved(xp,yp,zp,RpRs,wl,fx_list,mu_list,wlmin,wl
                 index = np.where(r < rlist)[-1][-1]
                 if mu_list[index] > 0:
                     fxc_wide = fx_list[index]
-                    # print(i,j,x[i],y[j],mu,mu_list[index])
                     F+=ops.shift(wlc,wlc_wide,fxc_wide,vel_grid[j,i])*flux_grid[j,i]
-    # print(time.time()-start)
     return(wlc,F,np.nansum(mask_i),(di*0.0)+1.0)
 
-
-
-    # F = 0#output
-    # flux = np.nansum(mask,axis = 0)#This is the sum of the flux grid.
-    # for i in range(len(x)):
-    #     for j in range(len(y)):
-    #         if np.isnan(mask[j,i]) == False:
-    #             F+=ops.shift(wlc,wlc_wide,fxc_wide,vel_grid[j,i])*flux_grid[j,i]
-    #     # statusbar(i,len(x))
-    # return(wlc,F,np.nansum(mask_i),(di*0.0)+1.0)

--- a/lib/operations.py
+++ b/lib/operations.py
@@ -1,13 +1,6 @@
 #This file contains a collection of functions that operate on spectra.
 def convolve(array,kernel,edge_degree=1,fit_width=2):
-    """It's unbelievable, but I could not find the python equivalent of IDL's
-    /edge_truncate keyword, which truncates the kernel at the edge of the convolution.
-    Therefore, unfortunately, I need to code a convolution operation myself.
-    Stand by to be slowed down by an order of magnitude #thankspython.
-
-    Nope! Because I can just use np.convolve for most of the array, just not the edge...
-
-    So the strategy is to extrapolate the edge of the array using a polynomial fit
+    """np.convolve with accounting for edge effects via extrapolation of the edge of the array using a polynomial fit
     to the edge elements. By default, I fit over a range that is twice the length of the kernel; but
     this value can be modified using the fit_width parameter.
 
@@ -68,7 +61,7 @@ def convolve(array,kernel,edge_degree=1,fit_width=2):
     array_padded = np.append(left_array_pad,array)
     array_padded = np.append(array_padded,right_array_pad)
 
-    #Reverse the kernel because np.convol does that automatically and I don't want that.
+    #Reverse the kernel because np.convol does that automatically.
     #(Imagine doing a derivative with a kernel [-1,0,1] and it gets reversed...)
     kr = kernel[::-1]
     #The valid keyword effectively undoes the padding, leaving only those values for which the kernel was entirely in the padded array.
@@ -135,9 +128,6 @@ def derivative(x):
     d_kernel=np.array([-1,0,1])/2.0
     return(convolve(x,d_kernel,fit_width=3))
 
-
-
-
 def constant_velocity_wl_grid(wl,fx,oversampling=1.0):
     """This function will define a constant-velocity grid that is (optionally)
     sampled a number of times finer than the SMALLEST velocity difference that is
@@ -184,7 +174,6 @@ def constant_velocity_wl_grid(wl,fx,oversampling=1.0):
     fx=np.array(fx)
 
     c=consts.c.to('km/s').value
-
 
     dl=derivative(wl)
     dv=dl/wl*c

--- a/lib/stellar_spectrum.py
+++ b/lib/stellar_spectrum.py
@@ -225,6 +225,7 @@ def get_spectrum_pysme(wave_start, wave_end, T, logg, Z, linelist = '', mu=[], a
     import numpy as np
     import ast
 
+    #initialise the pySME Object with values provided by the user
     sme = SME_Struct()
     sme.abund = Abund.solar()
     sme.teff, sme.logg, sme.monh = T, logg, Z
@@ -260,8 +261,12 @@ def get_spectrum_pysme(wave_start, wave_end, T, logg, Z, linelist = '', mu=[], a
             w, f = *sme.wave/10, *sme.synth
             wl = w
             fx.append(f.copy())
+            if len(w) < 5:
+                print("get_spectrum_pysme: It seems that your returned wavelength grid is shorter than expected. Please make sure that your line list has spectral lines in your specified wavelength range.")
         return(wl, fx)
 
     else:
         sme = synthesize_spectrum(sme)
+         if len(*sme.wave) < 5:
+                print("get_spectrum_pysme: It seems that your returned wavelength grid is shorter than expected. Please make sure that your line list has spectral lines in your specified wavelength range.")
         return(*sme.wave/10, *sme.synth)

--- a/lib/test.py
+++ b/lib/test.py
@@ -68,12 +68,6 @@ def test_smoothing():
     # Res_2 = KELT9.residuals()
     Res_3 = KELT9.residuals()
 
-
-
-    # plt.plot(KELT9.wl,F_unsmooth_1)
-    # plt.plot(KELT9.wl,F_smooth)
-    # plt.show()
-
     fig = plt.figure(figsize=(12,6))
     plt.plot(wl_low,Res_1[10],label='No blurring')
     plt.plot(wl_low,Res_2[10],label='Blurring, normal sampling')
@@ -115,7 +109,6 @@ def test_integrators():
     wl,fx = spectrum.read_spectrum(T,logg)
     wlF,F = integrate.build_spectrum_fast(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid)
 
-
     #Test the building of the local spectrum in-between.
     wlFp,Fp,fluxp,mask = integrate.build_local_spectrum_fast(0.4,0.0,0.15,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid)
     wlFp2,Fp2,fluxp2,mask2 = integrate.build_local_spectrum_slow(0.4,0.0,0.15,wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid)
@@ -123,23 +116,11 @@ def test_integrators():
     if epsilon > 1e-8:
         raise Exception("Error: The integrated difference of the local spectra built with the slow and fast integrators differs by more than 1e-8 times the integrated spectrum.")
 
-    #
-    # pdb.set_trace()
-    # pl.plot(wlF,F-np.nanmax(F))
-    # pl.plot(wlF,(F-Fp)-np.nanmax(F-Fp))
-    # pl.show()
-
     #Test the slow star integrator and compare.
     wlF2,F2 = integrate.build_spectrum_slow(wl,fx,wlmin,wlmax,x,y,vel_grid,flux_grid)
     epsilon = np.abs(np.nansum(F-F2)/np.nansum(F))
     if epsilon > 1e-8:
         raise Exception("Error: The integrated difference of the disk-integrated spectra built with the slow and fast integrators differs by more than 1e-8 times the integrated spectrum.")
-    # pl.plot(wl,fx)
-    # pl.plot(wlF,F)
-    # pl.plot(wlF2,F2)
-    # pl.xlim((550.0,560.0))
-    # pl.show()
-
 
 def test_plotting():
     import numpy as np
@@ -167,10 +148,6 @@ def test_plot_3D():
     import lib.plotting
     lib.plotting.plot_star_3D()
 
-
-
-
-#I copied the following functions from my own project that I use to test variables.
 def nantest(var,varname=''):
     import numpy as np
     if np.isnan(var).any()  == True:


### PR DESCRIPTION
Hi Jens,

See list of commits:

- I added a warning in the pySME wrapper if the output is too short (5 or less elements instead of hundreds in the output) as this is a hint that the incorrect line list was used to generate the stellar spectrum. This has happened to me and a student. However, as it 'might' be the desired behavior (I don't see when but who knows), it's not throwing an actual error, just providing a warning message in the terminal.
- In general, I have removed commented testing code (print statements, traces, etc)
- I have also updated commentary in general and added function descriptors where you put WRITE THIS. ;) 
- I have added another reference to the VALD section in the readme for the pySME section.

Cheers,

Julia